### PR TITLE
Docs: Use longhand flags in examples

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -48,25 +48,27 @@ aci https://example.com
 Or
 
 ```bash
-aci -s https://example.com
+aci --site https://example.com
 ```
 
 #### Limit the amount of pages scanned
 
 ```bash
-aci https://example.com -l 1
+aci https://example.com --pageLimit 1
 ```
 
 #### Scan a whole site and display results in the terminal
 
 ```bash
-aci https://example.com -d
+aci https://example.com -displayResults
 ```
 
 #### Ignore fragment links and query params
 
+Sometimes, sites use fragment links (`#section`) and query parameters (`?menu=open`) in the URL to indicate different states or positions in the document. You might want to ignore those if you get up too many duplicates and/or errors.
+
 ```bash
-aci https://example.com -i -q
+aci https://example.com --ignoreFragmentLinks --ignoreQueryParams
 ```
 
 ## Built With


### PR DESCRIPTION
## Proposed changes

This PR adds the longhand flags in examples
Shorthands are nice, sometimes, but the longhand flags are better both for new users and for documenting functionality. I think one of our former colleagues had a whole blog post about this, might have to dig it up :sweat_smile: 

The thing that ends up happening with CI scripts is that people put them in `package.json` or a shell script. I think the long-hand flags are better for documenting things in those settings.

## Types of changes

What types of changes does your code introduce?

*Put an `x` in the boxes that apply*

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Docs

## Checklist

*Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [X] I have read the [Contributing guidelines](./contributing.md)
- [X] All tests pass locally with my changes
- [X] I have added necessary documentation to the [readme file](./readme.md) (if appropriate)
