### PR TITLE
Adding default crawl limit and some helper descriptions

### DIFF
--- a/src/helpers/args.js
+++ b/src/helpers/args.js
@@ -3,7 +3,6 @@ const commandLineArgs = require('command-line-args');
 const commandLineUsage = require('command-line-usage');
 const { error, log } = require('./logger');
 
-
 const args = [
   {
     name: 'site',
@@ -11,7 +10,9 @@ const args = [
     type: url => new URL(url),
     typeLabel: '{underline url}',
     group: 'required',
-    defaultOption: true
+    defaultOption: true,
+    description:
+      'What is the base URL to begin crawling from? Must be a fully qualified URL, for example: https://example.com'
   },
   {
     name: 'ignoreExtensions',
@@ -28,7 +29,14 @@ const args = [
     defaultValue: false,
     group: 'optional'
   },
-  { name: 'pageLimit', alias: 'l', type: Number, group: 'optional' },
+  {
+    name: 'pageLimit',
+    alias: 'l',
+    type: Number,
+    defaultValue: 20,
+    group: 'optional',
+    description: 'How many pages do you want to crawl at most? Defaults to 20'
+  },
   {
     name: 'streaming',
     alias: 'm',
@@ -63,7 +71,12 @@ const args = [
     type: String,
     group: 'optional'
   },
-  { name: 'outputDirectory', alias: 'o', type: String, group: 'optional' },
+  {
+    name: 'outputDirectory',
+    alias: 'o',
+    type: String,
+    group: 'optional'
+  },
   {
     name: 'errorAverageThreshold',
     alias: 't',
@@ -90,9 +103,11 @@ function sortArgs(args) {
     if (left.alias < right.alias) {
       return -1;
     }
+
     if (left.alias > right.alias) {
       return 1;
     }
+
     return 0;
   });
 }


### PR DESCRIPTION
Fixes #1 and adds some help text for th `-s` and `-l` options.